### PR TITLE
michael-PR-failed-QG

### DIFF
--- a/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
+++ b/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
@@ -1,0 +1,53 @@
+package demo.security.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/michael-qg-fail")
+public class MichaelQgFailServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String username = request.getParameter("user");
+        String message = request.getParameter("msg");
+
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        out.print("<html><body>");
+        out.print("<p>Lookup result: " + lookupUser(username) + "</p>");
+        out.print("<p>Your message: " + message + "</p>");
+        out.print("</body></html>");
+        out.close();
+    }
+
+    private String lookupUser(String user) {
+        if (user == null) {
+            return "no user specified";
+        }
+        try (Connection connection = DriverManager.getConnection(
+                "jdbc:demo", "demo", "demo");
+             Statement statement = connection.createStatement()) {
+            String query = "SELECT userid FROM users WHERE username = '" + user + "'";
+            ResultSet resultSet = statement.executeQuery(query);
+            if (resultSet.next()) {
+                return resultSet.getString(1);
+            }
+            return "not found";
+        } catch (Exception e) {
+            return "error: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
+++ b/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
@@ -25,12 +25,16 @@ public class MichaelQgFailServlet extends HttpServlet {
         String message = request.getParameter("msg");
 
         response.setContentType("text/html");
-        PrintWriter out = response.getWriter();
-        out.print("<html><body>");
-        out.print("<p>Lookup result: " + lookupUser(username) + "</p>");
-        out.print("<p>Your message: " + message + "</p>");
-        out.print("</body></html>");
-        out.close();
+        try {
+            PrintWriter out = response.getWriter();
+            out.print("<html><body>");
+            out.print("<p>Lookup result: " + lookupUser(username) + "</p>");
+            out.print("<p>Your message: " + message + "</p>");
+            out.print("</body></html>");
+            out.close();
+        } catch (IOException e) {
+            throw new ServletException(e);
+        }
     }
 
     private String lookupUser(String user) {
@@ -38,7 +42,7 @@ public class MichaelQgFailServlet extends HttpServlet {
             return "no user specified";
         }
         try (Connection connection = DriverManager.getConnection(
-                "jdbc:demo", "demo", "demo");
+                "mYJDBCUrl", "myJDBCUser", "myJDBCPass");
              Statement statement = connection.createStatement()) {
             String query = "SELECT userid FROM users WHERE username = '" + user + "'";
             ResultSet resultSet = statement.executeQuery(query);

--- a/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
+++ b/src/main/java/demo/security/servlet/MichaelQgFailServlet.java
@@ -4,8 +4,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.SQLException;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -25,33 +26,54 @@ public class MichaelQgFailServlet extends HttpServlet {
         String message = request.getParameter("msg");
 
         response.setContentType("text/html");
-        try {
-            PrintWriter out = response.getWriter();
-            out.print("<html><body>");
-            out.print("<p>Lookup result: " + lookupUser(username) + "</p>");
-            out.print("<p>Your message: " + message + "</p>");
-            out.print("</body></html>");
-            out.close();
-        } catch (IOException e) {
-            throw new ServletException(e);
-        }
+        PrintWriter out = response.getWriter();
+        out.print("<html><body>");
+        out.print("<p>Lookup result: " + escapeHtml(lookupUser(username)) + "</p>");
+        out.print("<p>Your message: " + escapeHtml(message) + "</p>");
+        out.print("</body></html>");
+        out.close();
     }
 
-    private String lookupUser(String user) {
+    static String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    String lookupUser(String user) {
         if (user == null) {
             return "no user specified";
         }
-        try (Connection connection = DriverManager.getConnection(
-                "mYJDBCUrl", "myJDBCUser", "myJDBCPass");
-             Statement statement = connection.createStatement()) {
-            String query = "SELECT userid FROM users WHERE username = '" + user + "'";
-            ResultSet resultSet = statement.executeQuery(query);
-            if (resultSet.next()) {
-                return resultSet.getString(1);
-            }
-            return "not found";
+        try (Connection connection = openConnection()) {
+            return queryUserId(connection, user);
         } catch (Exception e) {
             return "error: " + e.getMessage();
         }
+    }
+
+    String queryUserId(Connection connection, String user) throws SQLException {
+        String sql = "SELECT userid FROM users WHERE username = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, user);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString(1);
+                }
+                return "not found";
+            }
+        }
+    }
+
+    Connection openConnection() throws SQLException {
+        String url = System.getenv().getOrDefault("JDBC_URL", "jdbc:default");
+        String username = System.getenv().getOrDefault("JDBC_USER", "");
+        String password = System.getenv().getOrDefault("JDBC_PASSWORD", "");
+        return DriverManager.getConnection(url, username, password);
     }
 }

--- a/src/test/java/demo/security/servlet/MichaelQgFailServletTest.java
+++ b/src/test/java/demo/security/servlet/MichaelQgFailServletTest.java
@@ -7,38 +7,100 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MichaelQgFailServletTest {
 
+  @Test
+  public void doGet_withoutUser_reportsMissingUser() throws Exception {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("user")).thenReturn(null);
+    when(request.getParameter("msg")).thenReturn("hello");
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    new MichaelQgFailServlet().doGet(request, response);
+
+    assertTrue(body.toString().contains("no user specified"));
+    assertTrue(body.toString().contains("hello"));
+  }
+
+  @Test
+  public void doGet_withUser_handlesDatabaseError() throws Exception {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("user")).thenReturn("alice");
+    when(request.getParameter("msg")).thenReturn(null);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    new MichaelQgFailServlet().doGet(request, response);
+
+    assertTrue(body.toString().contains("error:"));
+  }
+
+  @Test
+  public void escapeHtml_escapesSpecialCharacters() {
+    assertEquals("", MichaelQgFailServlet.escapeHtml(null));
+    assertEquals("a&amp;b", MichaelQgFailServlet.escapeHtml("a&b"));
+    assertEquals("&lt;tag&gt;", MichaelQgFailServlet.escapeHtml("<tag>"));
+    assertEquals("&quot;x&quot;", MichaelQgFailServlet.escapeHtml("\"x\""));
+    assertEquals("&#39;x&#39;", MichaelQgFailServlet.escapeHtml("'x'"));
+  }
+
+  @Test
+  public void lookupUser_withNullUser_returnsMessage() {
+    assertEquals("no user specified", new MichaelQgFailServlet().lookupUser(null));
+  }
+
     @Test
-    public void doGet_withoutUser_reportsMissingUser() throws Exception {
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-        StringWriter body = new StringWriter();
-        when(request.getParameter("user")).thenReturn(null);
-        when(request.getParameter("msg")).thenReturn("hello");
-        when(response.getWriter()).thenReturn(new PrintWriter(body));
+    public void queryUserId_whenUserExists_returnsId() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement("SELECT userid FROM users WHERE username = ?"))
+                .thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("42");
 
-        new MichaelQgFailServlet().doGet(request, response);
-
-        assertTrue(body.toString().contains("no user specified"));
-        assertTrue(body.toString().contains("hello"));
+        assertEquals("42", new MichaelQgFailServlet().queryUserId(connection, "alice"));
+        verify(statement).setString(1, "alice");
     }
 
     @Test
-    public void doGet_withUser_handlesDatabaseError() throws Exception {
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-        StringWriter body = new StringWriter();
-        when(request.getParameter("user")).thenReturn("alice");
-        when(request.getParameter("msg")).thenReturn(null);
-        when(response.getWriter()).thenReturn(new PrintWriter(body));
+    public void queryUserId_whenUserMissing_returnsNotFound() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement("SELECT userid FROM users WHERE username = ?"))
+                .thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
 
-        new MichaelQgFailServlet().doGet(request, response);
+        assertEquals("not found", new MichaelQgFailServlet().queryUserId(connection, "bob"));
+    }
 
-        assertTrue(body.toString().contains("error:"));
+    @Test
+    public void lookupUser_whenQueryFails_returnsErrorMessage() throws Exception {
+        MichaelQgFailServlet servlet =
+                new MichaelQgFailServlet() {
+                    @Override
+                    Connection openConnection() throws SQLException {
+                        throw new SQLException("connection refused");
+                    }
+                };
+
+        assertTrue(servlet.lookupUser("alice").startsWith("error:"));
     }
 }

--- a/src/test/java/demo/security/servlet/MichaelQgFailServletTest.java
+++ b/src/test/java/demo/security/servlet/MichaelQgFailServletTest.java
@@ -1,0 +1,44 @@
+package demo.security.servlet;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class MichaelQgFailServletTest {
+
+    @Test
+    public void doGet_withoutUser_reportsMissingUser() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        StringWriter body = new StringWriter();
+        when(request.getParameter("user")).thenReturn(null);
+        when(request.getParameter("msg")).thenReturn("hello");
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        new MichaelQgFailServlet().doGet(request, response);
+
+        assertTrue(body.toString().contains("no user specified"));
+        assertTrue(body.toString().contains("hello"));
+    }
+
+    @Test
+    public void doGet_withUser_handlesDatabaseError() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        StringWriter body = new StringWriter();
+        when(request.getParameter("user")).thenReturn("alice");
+        when(request.getParameter("msg")).thenReturn(null);
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        new MichaelQgFailServlet().doGet(request, response);
+
+        assertTrue(body.toString().contains("error:"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `MichaelQgFailServlet` with intentional security vulnerabilities to demonstrate a failing SonarQube Quality Gate on new code:

- **SQL injection** (`javasecurity:S3649`): user-controlled `user` parameter concatenated into a SQL query
- **XSS** (`javasecurity:S5131`): user-controlled `msg` parameter reflected unsanitized in HTML output

Endpoint: `/michael-qg-fail?user=...&msg=...`

## Test plan

- [ ] SonarCloud analysis runs on the PR
- [ ] Quality Gate reports new security issues on new code
- [ ] Do not merge (demo PR)