### PR TITLE
Add SSRF and XXE vulnerability demo servlets

### DIFF
--- a/src/main/java/demo/security/servlet/SsrfServlet.java
+++ b/src/main/java/demo/security/servlet/SsrfServlet.java
@@ -1,0 +1,20 @@
+package demo.security.servlet;
+
+import demo.security.util.Utils;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/ssrf")
+public class SsrfServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String url = request.getParameter("url");
+        String body = Utils.fetchUrl(url);
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/demo/security/servlet/XxeServlet.java
+++ b/src/main/java/demo/security/servlet/XxeServlet.java
@@ -1,0 +1,25 @@
+package demo.security.servlet;
+
+import demo.security.util.Utils;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import org.xml.sax.SAXException;
+
+@WebServlet("/xxe")
+public class XxeServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String xml = request.getParameter("xml");
+        try {
+            Utils.parseXml(xml);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/src/main/java/demo/security/util/Utils.java
+++ b/src/main/java/demo/security/util/Utils.java
@@ -2,6 +2,7 @@ package demo.security.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
+import org.w3c.dom.Document;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -9,12 +10,20 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.*;
+import org.xml.sax.SAXException;
 
 public class Utils {
 
@@ -48,5 +57,17 @@ public class Utils {
         GCMParameterSpec gcmSpec = new GCMParameterSpec(128, nonce);
 
         cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec); // Noncompliant
+    }
+
+    public static String fetchUrl(String url) throws IOException {
+        URL target = new URL(url); // Noncompliant - untrusted URL, no allowlist/scheme check (SSRF)
+        URLConnection connection = target.openConnection();
+        return new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    public static Document parseXml(String xml) throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance(); // Noncompliant - external entities not disabled (XXE)
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
## Summary
- New `/ssrf` endpoint (`SsrfServlet`) -> `Utils.fetchUrl(url)`: opens an attacker-controlled URL with no allowlist/scheme check.
- New `/xxe` endpoint (`XxeServlet`) -> `Utils.parseXml(xml)`: `DocumentBuilderFactory` with external entities left enabled.
- Matches the existing insecure-demo pattern (`FileServlet`, `ScriptServlet`, `Insecure`) for SonarQube detection showcase.

## Test plan
- [ ] SonarQube analysis flags `java:S2755` (XXE) on `Utils.java` and SSRF hotspot on the `/ssrf` path.
- [ ] `POST /xxe` with XML payload containing external entity confirms vuln live.
- [ ] `POST /ssrf` with internal-network URL confirms fetch unrestricted.

Generated with Claude Code