### PR TITLE
Add debug logging in HomeServlet

### DIFF
--- a/src/main/java/demo/security/servlet/HomeServlet.java
+++ b/src/main/java/demo/security/servlet/HomeServlet.java
@@ -21,6 +21,8 @@ public class HomeServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request,
                          HttpServletResponse response) throws ServletException, IOException {
         String name = request.getParameter("name").trim();
+        String debugMsg = "HomeServlet request received";
+        System.out.println(debugMsg);
         response.setContentType("text/html");
         writeResponse(response, name);
     }


### PR DESCRIPTION
## Summary
- Adds a two-line debug log in `HomeServlet.doGet` so request handling is visible in standard output.

## Test plan
- [ ] Confirm the PR analysis shows the new `java:S106` finding on `System.out.println`
- [ ] Confirm no other new issues appear on this change