### PR TITLE
Add MySQL JDBC driver so DBUtils can open a connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,14 @@
       <artifactId>commons-codec</artifactId>
       <version>1.16.0</version>
     </dependency>
+    <!-- MySQL JDBC driver, so DBUtils.getConnection() can resolve a real
+         driver at runtime instead of failing with "No suitable driver".
+         Licensed under GPL-2.0. -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.49</version>
+    </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>


### PR DESCRIPTION
`DBUtils` calls `DriverManager.getConnection()` but no JDBC driver is on the runtime classpath, so every connection attempt fails with "No suitable driver found".

This adds the MySQL Connector/J driver so the servlets backed by `DBUtils` can actually reach a database.

- Single new dependency, no transitive dependencies
- `mvn verify` passes locally (4/4 tests)